### PR TITLE
Edit button fixing 2

### DIFF
--- a/Components/Pages/AddPlant.razor
+++ b/Components/Pages/AddPlant.razor
@@ -216,7 +216,8 @@
 <!-- Display the form for creating a custom plant -->
 @if (showCustomForm)
 {
-    <EditForm Model="plant" OnSubmit="HandleSubmit" FormName="editPlant">
+    // Pressing 'Submit' here goes specifically to the CustomHandleSubmit method
+    <EditForm Model="plant" OnSubmit="CustomHandleSubmit" FormName="editPlant">
 
         <!-- Input field for plant name -->
         <label>Plant Name</label>
@@ -253,6 +254,7 @@
 // Display the form for selecting a prefilled plant 
 else if (showPrefilledForm) 
 {
+    // Pressing 'Submit' here goes specifically to the PrefilledHandleSubmit method
     <EditForm Model="plant" OnSubmit="PrefillHandleSubmit" FormName="editPlant">
 
         <!-- Dropdown to select an existing public plant -->
@@ -329,11 +331,9 @@ else if (showPrefilledForm)
     }
 
     // ******************************************************************************
-    // Handles the submission of a new plant, either as a pre-filled copy of an existing plant
-    // or as a custom user-created plant. If a pre-filled plant is selected, it clones the
-    // existing plant and its associated tasks. Otherwise, it creates a new custom plant.
+    // Handles the submission of custom plants and edited plants
     // ******************************************************************************
-    async Task HandleSubmit()
+    async Task CustomHandleSubmit()
     {
         // Get the user's unique ID
         plant.USER_ID = await UserServices.GetUserID(user_email);
@@ -407,7 +407,9 @@ else if (showPrefilledForm)
         NavigationManager.NavigateTo("/Garden", forceLoad: true);
     }
 
-    //**********************************************************************************************/
+    // ******************************************************************************
+    // Handles the submission of a pre-filled plant only
+    // ******************************************************************************
     async Task PrefillHandleSubmit()
     {
         // Get the user's unique ID

--- a/Components/Pages/AddPlant.razor
+++ b/Components/Pages/AddPlant.razor
@@ -253,7 +253,7 @@
 // Display the form for selecting a prefilled plant 
 else if (showPrefilledForm) 
 {
-    <EditForm Model="plant" OnSubmit="HandleSubmit" FormName="editPlant">
+    <EditForm Model="plant" OnSubmit="PrefillHandleSubmit" FormName="editPlant">
 
         <!-- Dropdown to select an existing public plant -->
         <label>Select a Public Plant</label>
@@ -400,6 +400,86 @@ else if (showPrefilledForm)
                 {
                     // Only save tasks that have a valid frequency
                     if (task.FREQ > 0) 
+                    {
+                        await PlantService.AddTask(task);
+                    }
+                }
+            }
+        }
+        // Notify the parent component that the submission is complete
+        await OnSubmit.InvokeAsync();
+        // Navigate back to the garden page and refresh the data
+        NavigationManager.NavigateTo("/Garden", forceLoad: true);
+    }
+
+    //**********************************************************************************************/
+    async Task PrefillHandleSubmit()
+    {
+        // Get the user's unique ID
+        plant.USER_ID = await UserServices.GetUserID(user_email);
+
+        // Check if the user selected a pre-filled plant
+        if (selectedPublicPlantId.HasValue)
+        {
+            // Retrieve the original plant from the database
+            var originalPlant = await PlantService.GetPlantByID(selectedPublicPlantId.Value);
+            if (originalPlant != null)
+            {
+                // Create a new plant based on the original, but assign it to the current user
+                plant = new Plants
+                    {
+                        PLANT_NAME = originalPlant.PLANT_NAME,
+                        IMAGE_DATA = originalPlant.IMAGE_DATA,
+                        USER_ID = await UserServices.GetUserID(user_email),
+                        IS_PRIVATE = "Y"
+                    };
+
+                // Save the new plant to the database
+                var newPlant = await PlantService.AddPlants(plant);
+
+                if (newPlant != null)
+                {
+                    // Retrieve the original plant's tasks
+                    var originalTasks = await PlantService.GetTasksForPlant(originalPlant.PLANT_ID);
+                    foreach (var task in originalTasks)
+                    {
+                        // Create a new task linked to the newly created plant
+                        var newTask = new PlantTask
+                            {
+                                PLANT_ID = newPlant.PLANT_ID, // Assign the new plant's ID
+                                TASK_NAME = task.TASK_NAME,
+                                FREQ = task.FREQ,
+                                DAYS_UNTIL = task.DAYS_UNTIL,
+                                IS_COMPLETED = false, // Reset task status
+                                DONE_DATE = null,
+                                OVERDUE = 0
+                            };
+                        // Save the cloned task in the database
+                        await PlantService.AddTask(newTask);
+                    }
+                }
+            }
+        }
+        else
+        {
+            // Create a custom plant with user-defined details
+            var addedPlant = await PlantService.AddPlants(plant);
+
+            if (addedPlant != null)
+            {
+                // Define tasks based on user input for frequency
+                var taskList = new List<PlantTask>
+                {
+                    new PlantTask { PLANT_ID = addedPlant.PLANT_ID, TASK_NAME = "Watering", FREQ = waterFreq },
+                    new PlantTask { PLANT_ID = addedPlant.PLANT_ID, TASK_NAME = "Weeding", FREQ = weedFreq },
+                    new PlantTask { PLANT_ID = addedPlant.PLANT_ID, TASK_NAME = "Pruning", FREQ = pruneFreq },
+                    new PlantTask { PLANT_ID = addedPlant.PLANT_ID, TASK_NAME = "Pest Control", FREQ = pestFreq }
+                };
+
+                foreach (var task in taskList)
+                {
+                    // Only save tasks that have a valid frequency
+                    if (task.FREQ > 0)
                     {
                         await PlantService.AddTask(task);
                     }

--- a/Components/Pages/AddPlant.razor
+++ b/Components/Pages/AddPlant.razor
@@ -338,51 +338,49 @@ else if (showPrefilledForm)
         // Get the user's unique ID
         plant.USER_ID = await UserServices.GetUserID(user_email);
 
-        // Check if the user selected a pre-filled plant
-        if (selectedPublicPlantId.HasValue) 
+        // Check if the plant is an edit (already exists)
+        if (PLANT_ID.HasValue && PLANT_ID > 0)
         {
-            // Retrieve the original plant from the database
-            var originalPlant = await PlantService.GetPlantByID(selectedPublicPlantId.Value);
-            if (originalPlant != null)
+            var existingPlant = await PlantService.GetPlantByID(PLANT_ID.Value);
+            if (existingPlant != null)
             {
-                // Create a new plant based on the original, but assign it to the current user
-                plant = new Plants
-                    {
-                        PLANT_NAME = originalPlant.PLANT_NAME,
-                        IMAGE_DATA = originalPlant.IMAGE_DATA,
-                        USER_ID = await UserServices.GetUserID(user_email), 
-                        IS_PRIVATE = "Y" 
-                    };
+                // Update the existing plant's name & image with the new value & image
+                existingPlant.PLANT_NAME = plant.PLANT_NAME;
+                existingPlant.IMAGE_DATA = plant.IMAGE_DATA;
 
-                // Save the new plant to the database
-                var newPlant = await PlantService.AddPlants(plant);
+                // Update plant in database
+                await PlantService.UpdatePlant(existingPlant);
 
-                if (newPlant != null)
+                // Retrieve existing tasks
+                var existingTasks = await PlantService.GetTasksForPlant(existingPlant.PLANT_ID);
+
+                // Iterate through all existing tasks linked to the plant
+                foreach (var task in existingTasks)
                 {
-                    // Retrieve the original plant's tasks
-                    var originalTasks = await PlantService.GetTasksForPlant(originalPlant.PLANT_ID);
-                    foreach (var task in originalTasks)
+                    // Update the task's frequency based on the user-input values
+                    switch (task.TASK_NAME)
                     {
-                        // Create a new task linked to the newly created plant
-                        var newTask = new PlantTask
-                            {
-                                PLANT_ID = newPlant.PLANT_ID, // Assign the new plant's ID
-                                TASK_NAME = task.TASK_NAME,
-                                FREQ = task.FREQ,
-                                DAYS_UNTIL = task.DAYS_UNTIL,
-                                IS_COMPLETED = false, // Reset task status
-                                DONE_DATE = null,
-                                OVERDUE = 0
-                            };
-                        // Save the cloned task in the database
-                        await PlantService.AddTask(newTask);
+                        case "Watering":
+                            task.FREQ = waterFreq;
+                            break;
+                        case "Weeding":
+                            task.FREQ = weedFreq;
+                            break;
+                        case "Pruning":
+                            task.FREQ = pruneFreq;
+                            break;
+                        case "Pest Control":
+                            task.FREQ = pestFreq;
+                            break;
                     }
+                    // Save the updated task back to the database
+                    await PlantService.UpdateTask(task);
                 }
             }
         }
         else
         {
-            // Create a custom plant with user-defined details
+            // Create a new plant
             var addedPlant = await PlantService.AddPlants(plant);
 
             if (addedPlant != null)
@@ -390,19 +388,16 @@ else if (showPrefilledForm)
                 // Define tasks based on user input for frequency
                 var taskList = new List<PlantTask>
                 {
-                    new PlantTask { PLANT_ID = addedPlant.PLANT_ID, TASK_NAME = "Watering", FREQ = waterFreq },
-                    new PlantTask { PLANT_ID = addedPlant.PLANT_ID, TASK_NAME = "Weeding", FREQ = weedFreq },
-                    new PlantTask { PLANT_ID = addedPlant.PLANT_ID, TASK_NAME = "Pruning", FREQ = pruneFreq },
-                    new PlantTask { PLANT_ID = addedPlant.PLANT_ID, TASK_NAME = "Pest Control", FREQ = pestFreq }
+                new PlantTask { PLANT_ID = addedPlant.PLANT_ID, TASK_NAME = "Watering", FREQ = waterFreq },
+                new PlantTask { PLANT_ID = addedPlant.PLANT_ID, TASK_NAME = "Weeding", FREQ = weedFreq },
+                new PlantTask { PLANT_ID = addedPlant.PLANT_ID, TASK_NAME = "Pruning", FREQ = pruneFreq },
+                new PlantTask { PLANT_ID = addedPlant.PLANT_ID, TASK_NAME = "Pest Control", FREQ = pestFreq }
                 };
 
                 foreach (var task in taskList)
                 {
                     // Only save tasks that have a valid frequency
-                    if (task.FREQ > 0) 
-                    {
-                        await PlantService.AddTask(task);
-                    }
+                    await PlantService.AddTask(task);
                 }
             }
         }
@@ -456,32 +451,6 @@ else if (showPrefilledForm)
                             };
                         // Save the cloned task in the database
                         await PlantService.AddTask(newTask);
-                    }
-                }
-            }
-        }
-        else
-        {
-            // Create a custom plant with user-defined details
-            var addedPlant = await PlantService.AddPlants(plant);
-
-            if (addedPlant != null)
-            {
-                // Define tasks based on user input for frequency
-                var taskList = new List<PlantTask>
-                {
-                    new PlantTask { PLANT_ID = addedPlant.PLANT_ID, TASK_NAME = "Watering", FREQ = waterFreq },
-                    new PlantTask { PLANT_ID = addedPlant.PLANT_ID, TASK_NAME = "Weeding", FREQ = weedFreq },
-                    new PlantTask { PLANT_ID = addedPlant.PLANT_ID, TASK_NAME = "Pruning", FREQ = pruneFreq },
-                    new PlantTask { PLANT_ID = addedPlant.PLANT_ID, TASK_NAME = "Pest Control", FREQ = pestFreq }
-                };
-
-                foreach (var task in taskList)
-                {
-                    // Only save tasks that have a valid frequency
-                    if (task.FREQ > 0)
-                    {
-                        await PlantService.AddTask(task);
                     }
                 }
             }

--- a/Services/IPlantService.cs
+++ b/Services/IPlantService.cs
@@ -37,5 +37,11 @@ namespace greenhouse.Services
         // Adds a new task to the PlantTasks table
         Task<bool> AddTask(PlantTask task);
 
+        // Update an existing plant's details in the database
+        Task<bool> UpdatePlant(Plants plant);
+
+        // Update an existing task's details in the database
+        Task<bool> UpdateTask(PlantTask task);
+
     }
 }

--- a/Services/PlantService.cs
+++ b/Services/PlantService.cs
@@ -134,6 +134,26 @@ namespace greenhouse.Services
             _context.PlantTasks.Add(task);                  // Adds the new task record to the database context     
             await _context.SaveChangesAsync();              // Saves changes asynchronously to persist the new task
             return true;                                    // Returns true to indicate successful insertion
-        }  
+        }
+
+        // ******************************************************************************
+        //            UPDATE PLANT
+        // ******************************************************************************
+        public async Task<bool> UpdatePlant(Plants plant)
+        {
+            _context.Plant.Update(plant);
+            await _context.SaveChangesAsync();
+            return true;
+        }
+
+        // ******************************************************************************
+        //         UPDATE TASK
+        // ******************************************************************************
+        public async Task<bool> UpdateTask(PlantTask task)
+        {
+            _context.PlantTasks.Update(task);
+            await _context.SaveChangesAsync();
+            return true;
+        }
     }
 }

--- a/Services/PlantService.cs
+++ b/Services/PlantService.cs
@@ -137,7 +137,7 @@ namespace greenhouse.Services
         }
 
         // ******************************************************************************
-        //            UPDATE PLANT
+        // Updates an existing plant's details in the database.
         // ******************************************************************************
         public async Task<bool> UpdatePlant(Plants plant)
         {
@@ -147,7 +147,7 @@ namespace greenhouse.Services
         }
 
         // ******************************************************************************
-        //         UPDATE TASK
+        // Updates an existing plant task's details in the database.
         // ******************************************************************************
         public async Task<bool> UpdateTask(PlantTask task)
         {


### PR DESCRIPTION
MERGE TO TEST:
I completely separated the logic for handling Prefilled and Custom plant submissions. Previously, there was overlap that caused one submission type to interfere with the other. Now, each button is handled independently, ensuring that each plant type is processed correctly. This prevents unintended data overwrites and improves clarity in how each submission is managed.