### PR TITLE
if they dont choose a plant image, give them a default image

### DIFF
--- a/Components/Pages/AddPlant.razor
+++ b/Components/Pages/AddPlant.razor
@@ -527,6 +527,14 @@ else if (showPrefilledForm)
         {
             plant.IMAGE_DATA = selectedPlant.IMAGE_DATA;
         }
+        else
+        {
+            var defaultImagePath = Path.Combine("wwwroot", "images", "Default.webp");
+            if (File.Exists(defaultImagePath))
+            {
+                plant.IMAGE_DATA = await File.ReadAllBytesAsync(defaultImagePath);
+            }
+        }
 
         // Check if the plant is an edit (already exists)
         if (PLANT_ID.HasValue && PLANT_ID > 0)


### PR DESCRIPTION
Added logic to assign the default plant image (Default.webp) when no image is selected by the user. This ensures every new plant has a visible image, even if one isn't chosen.